### PR TITLE
Fix FR slug mismatch and HTML translation rendering

### DIFF
--- a/src/content/blog/blog-with-vps.fr.md
+++ b/src/content/blog/blog-with-vps.fr.md
@@ -4,6 +4,7 @@ description: "Apprenez à créer votre propre blog : un guide étape par étape 
 pubDate: "Sept 25 2023"
 updatedDate: "April 2 2024"
 heroImage: "/blog/blog-with-vps/blog-with-vps-hero.webp"
+slug: "blog-with-vps"
 lang: "fr"
 isVisible: true
 ---

--- a/src/content/blog/blog-with-vps.md
+++ b/src/content/blog/blog-with-vps.md
@@ -4,6 +4,7 @@ description: "Learn How to Create Your Own Blog: A Step-by-Step Guide to Hosting
 pubDate: "Sept 25 2023"
 updatedDate: "April 2 2024"
 heroImage: "/blog/blog-with-vps/blog-with-vps-hero.webp"
+slug: "blog-with-vps"
 lang: "en"
 isVisible: true
 ---

--- a/src/content/projects/NBodySimulation.fr.md
+++ b/src/content/projects/NBodySimulation.fr.md
@@ -5,6 +5,7 @@ pubDate: "Jan 11 2024"
 updatedDate: "April 2 2024"
 heroImage: "/projects/nbody/nbody-hero.png"
 heroGif: "/projects/nbody/nbody-gif.gif"
+slug: "NBodySimulation"
 lang: "fr"
 isVisible: true
 ---

--- a/src/content/projects/NBodySimulation.md
+++ b/src/content/projects/NBodySimulation.md
@@ -5,6 +5,7 @@ pubDate: "Jan 11 2024"
 updatedDate: "April 2 2024"
 heroImage: "/projects/nbody/nbody-hero.png"
 heroGif: "/projects/nbody/nbody-gif.gif"
+slug: "NBodySimulation"
 lang: "en"
 isVisible: true
 ---

--- a/src/content/projects/Steganography.fr.md
+++ b/src/content/projects/Steganography.fr.md
@@ -5,6 +5,7 @@ pubDate: "April 30 2024"
 updatedDate: "Sept 23 2024"
 heroImage: "/projects/steganography/steganography-hero.png"
 heroGif: ""
+slug: "Steganography"
 lang: "fr"
 isVisible: true
 ---

--- a/src/content/projects/Steganography.md
+++ b/src/content/projects/Steganography.md
@@ -5,6 +5,7 @@ pubDate: "April 30 2024"
 updatedDate: "Sept 23 2024"
 heroImage: "/projects/steganography/steganography-hero.png"
 heroGif: ""
+slug: "Steganography"
 lang: "en"
 isVisible: true
 ---

--- a/src/pages/[lang]/about.astro
+++ b/src/pages/[lang]/about.astro
@@ -27,17 +27,17 @@ const formattedDate: string = originalDate.toLocaleString("fr-FR", {
     heroImage=""
 >
     <h4>{t("about.academic.title")}</h4>
-    <p>{t("about.academic.text")}</p>
+    <p set:html={t("about.academic.text")}></p>
 
     <h5>{t("about.bts.title")}</h5>
-    <p>{t("about.bts.text")}</p>
+    <p set:html={t("about.bts.text")}></p>
 
     <h5>{t("about.lp.title")}</h5>
-    <p>{t("about.lp.text")}</p>
+    <p set:html={t("about.lp.text")}></p>
 
     <h5>{t("about.master.title")}</h5>
-    <p>{t("about.master.text")}</p>
+    <p set:html={t("about.master.text")}></p>
 
     <h4>{t("about.server.title")}</h4>
-    <p>{t("about.server.text", formattedDate)}</p>
+    <p set:html={t("about.server.text", formattedDate)}></p>
 </Layout>

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -5,7 +5,7 @@ import Post from "../../../layouts/Post.astro";
 export async function getStaticPaths() {
     const posts = await getCollection("blog");
     return posts.map((post) => ({
-        params: { lang: post.data.lang, slug: post.slug },
+        params: { lang: post.data.lang, slug: post.data.slug },
         props: post,
     }));
 }

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -105,7 +105,7 @@ const posts = (await getCollection("blog"))
                     {
                         posts.map((post) => (
                             <li>
-                                <a href={`/${lang}/blog/${post.slug}/`}>
+                                <a href={`/${lang}/blog/${post.data.slug}/`}>
                                     <Image
                                         width={720}
                                         height={360}

--- a/src/pages/[lang]/projects/[...slug].astro
+++ b/src/pages/[lang]/projects/[...slug].astro
@@ -4,7 +4,7 @@ import Post from "../../../layouts/Post.astro";
 export async function getStaticPaths() {
     const posts = await getCollection("projects");
     return posts.map((post) => ({
-        params: { lang: post.data.lang, slug: post.slug },
+        params: { lang: post.data.lang, slug: post.data.slug },
         props: post,
     }));
 }

--- a/src/pages/[lang]/projects/index.astro
+++ b/src/pages/[lang]/projects/index.astro
@@ -104,7 +104,7 @@ const posts = (await getCollection("projects"))
                     {
                         posts.map((post) => (
                             <li>
-                                <a href={`/${lang}/projects/${post.slug}/`}>
+                                <a href={`/${lang}/projects/${post.data.slug}/`}>
                                     <Image
                                         width={720}
                                         height={360}

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -13,7 +13,7 @@ export async function GET(context) {
         site: context.site,
         items: posts.map((post) => ({
             ...post.data,
-            link: `/${DEFAULT_LANG}/blog/${post.slug}/`,
+            link: `/${DEFAULT_LANG}/blog/${post.data.slug}/`,
         })),
     });
 }


### PR DESCRIPTION
## Summary
- ensure French posts use the same slug as their English counterpart
- render translation strings containing HTML correctly
- use slug frontmatter for dynamic blog and project routes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68401d6976f08323b12e0f0e9394dd8e