### PR TITLE
Remove Spanish locale and add flag switcher

### DIFF
--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -1,5 +1,9 @@
 ---
 import { getLocalizedPathname, LANGUAGES } from "../i18n/utils";
+const flags = {
+    en: "🇬🇧",
+    fr: "🇫🇷",
+} as const;
 interface Props {
     lang: string;
 }
@@ -11,7 +15,7 @@ const otherLangs = Object.keys(LANGUAGES).filter((l) => l !== lang);
     {
         otherLangs.map((l) => (
             <a href={getLocalizedPathname(Astro.url.pathname, l)}>
-                {l.toUpperCase()}
+                {flags[l]}
             </a>
         ))
     }

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -10,9 +10,17 @@ const blog = defineCollection({
         updatedDate: z.coerce.date().optional(),
         heroImage: z.string().optional(),
         heroGif: z.string().optional(),
+        slug: z.string().optional(),
         lang: z.string(),
         isVisible: z.boolean().default(false),
     }),
+    slug: ({ id, data }) =>
+        data.slug ??
+        id
+            .split("/")
+            .pop()
+            ?.replace(/\.mdx?$/, "")
+            ?.replace(/\.fr$/, "") ?? id,
 });
 
 const projects = defineCollection({
@@ -25,9 +33,17 @@ const projects = defineCollection({
         updatedDate: z.coerce.date().optional(),
         heroImage: z.string().optional(),
         heroGif: z.string().optional(),
+        slug: z.string().optional(),
         lang: z.string(),
         isVisible: z.boolean().default(false),
     }),
+    slug: ({ id, data }) =>
+        data.slug ??
+        id
+            .split("/")
+            .pop()
+            ?.replace(/\.mdx?$/, "")
+            ?.replace(/\.fr$/, "") ?? id,
 });
 
 export const collections = {

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -109,34 +109,4 @@ export const ui = {
         "about.server.title": "Informations serveur",
         "about.server.text": "Ce site est hébergé sur <a href=\"https://pulseheberg.com\">pulseheberg</a> et la dernière mise à jour réussie date du {0}.",
     },
-    es: {
-        "site.title": "Astro Blog",
-        "site.description": "Bienvenido a mi sitio web!",
-        "nav.home": "Inicio",
-        "nav.about": "Quien soy",
-        "home.welcome": "Bienvenido a mi sitio web",
-        "about.title": "Sobre mi",
-        "about.description": "Soy un desarrollador web y me encanta Astro!",
-        "about.text": `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-		labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo
-		viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam
-		adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus
-		et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus
-		vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque
-		sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.`,
-        "home.p1": `Bienvenido a la plantilla de inicio de blog oficial. Esta plantilla sirve como punto de partida ligero y con estilo mínimo para cualquiera que quiera construir un sitio web personal, un blog o un portafolio con Astro.`,
-        "home.p2": `Esta plantilla viene con algunas integraciones ya configuradas en su archivo <code>astro.config.mjs</code>. Puede personalizar su configuración con <a href="https://astro.build/integrations">Astro Integrations</a> para agregar herramientas como Tailwind, React o Vue a su proyecto.`,
-        "home.p3":
-            "Aquí hay algunas ideas sobre cómo comenzar con la plantilla:",
-        "home.p3.0": "Maneje las traducciones en",
-        "home.p3.1": "Edite esta página en",
-        "home.p3.2": "Editar páginas traducidas en",
-        "home.p3.3": "Edite los elementos de encabezado del sitio en",
-        "home.p3.4": "Agregue su nombre al pie de página en",
-        "home.p3.5":
-            "Consulte las publicaciones de blog incluidas en idiomas ES, EN y FR en",
-        "home.p3.6": "Personalice el diseño general del sitio en",
-        "home.p3.7":
-            "Personalice el diseño de la página de publicación del blog en",
-    },
 } as const;

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -3,7 +3,6 @@ import { ui } from "./ui";
 export const LANGUAGES = {
     en: "English",
     fr: "Français",
-    es: "Español",
 };
 
 export const DEFAULT_LANG = "en";

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -5,7 +5,7 @@ import Post from "../../../layouts/Post.astro";
 export async function getStaticPaths() {
     const posts = await getCollection("blog");
     return posts.map((post) => ({
-        params: { lang: post.data.lang, slug: post.data.slug },
+        params: { lang: post.data.lang, slug: post.slug },
         props: post,
     }));
 }

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -105,7 +105,7 @@ const posts = (await getCollection("blog"))
                     {
                         posts.map((post) => (
                             <li>
-                                <a href={`/${lang}/blog/${post.data.slug}/`}>
+                                <a href={`/${lang}/blog/${post.slug}/`}>
                                     <Image
                                         width={720}
                                         height={360}

--- a/src/pages/[lang]/projects/[...slug].astro
+++ b/src/pages/[lang]/projects/[...slug].astro
@@ -4,7 +4,7 @@ import Post from "../../../layouts/Post.astro";
 export async function getStaticPaths() {
     const posts = await getCollection("projects");
     return posts.map((post) => ({
-        params: { lang: post.data.lang, slug: post.data.slug },
+        params: { lang: post.data.lang, slug: post.slug },
         props: post,
     }));
 }

--- a/src/pages/[lang]/projects/index.astro
+++ b/src/pages/[lang]/projects/index.astro
@@ -104,7 +104,7 @@ const posts = (await getCollection("projects"))
                     {
                         posts.map((post) => (
                             <li>
-                                <a href={`/${lang}/projects/${post.data.slug}/`}>
+                                <a href={`/${lang}/projects/${post.slug}/`}>
                                     <Image
                                         width={720}
                                         height={360}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,14 @@
+---
+import { DEFAULT_LANG } from "../i18n/utils";
+const redirectUrl = `/${DEFAULT_LANG}/`;
+---
+<html>
+  <head>
+    <meta http-equiv="refresh" content={`0; url=${redirectUrl}`} />
+    <link rel="canonical" href={redirectUrl} />
+    <title>Redirecting...</title>
+  </head>
+  <body>
+    <p>Redirecting to <a href={redirectUrl}>{redirectUrl}</a></p>
+  </body>
+</html>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -13,7 +13,7 @@ export async function GET(context) {
         site: context.site,
         items: posts.map((post) => ({
             ...post.data,
-            link: `/${DEFAULT_LANG}/blog/${post.data.slug}/`,
+            link: `/${DEFAULT_LANG}/blog/${post.slug}/`,
         })),
     });
 }


### PR DESCRIPTION
## Summary
- remove Spanish translations from `ui.ts`
- remove `es` from language utilities
- show flag icons in the language switcher
- add top-level redirect to default language
- fix slug generation so localized project pages build correctly

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840224b9ad08323a7419cd793746bc3