### PR TITLE
Fix mobile header layout

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -66,14 +66,15 @@ const t = useTranslations(lang);
 <style>
     .internal-links {
         display: flex;
+        flex-wrap: wrap;
         align-items: center;
         gap: 1em;
     }
 
     header {
-        height: 6svh;
+        min-height: 4em;
         margin: 0;
-        padding: 0 1em;
+        padding: 0.5em 1em;
         background: rgb(var(--bg-color-accent));
         box-shadow: 0 2px 8px rgba(var(--gray), 5%);
     }
@@ -113,11 +114,18 @@ const t = useTranslations(lang);
             display: none;
         }
         .container {
-            flex-wrap: wrap;
+            flex-direction: column;
+            align-items: flex-start;
             gap: 0.5em;
         }
+        .internal-links {
+            flex-wrap: wrap;
+            gap: 0.5em;
+            width: 100%;
+            justify-content: flex-start;
+        }
         .internal-links a {
-            padding: 0.25em;
+            padding: 0.25em 0.5em;
         }
     }
 </style>


### PR DESCRIPTION
## Summary
- improve header responsiveness by letting it grow vertically
- wrap internal nav items when needed
- stack header content on small screens

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684039b3efc08323bcee2e390d495f0e