### PR TITLE
Fix header width on desktop

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -76,7 +76,8 @@ function isActive(prefix: string) {
     }
 
     .container {
-        max-width: 1020px;
+        max-width: var(--content-width);
+        width: 100%;
         margin: 0 auto;
         display: flex;
         align-items: center;

--- a/src/components/HeroImage.astro
+++ b/src/components/HeroImage.astro
@@ -7,9 +7,9 @@ const { heroImage, heroGif } = Astro.props;
 <style>
     .hero-image-container {
         position: relative;
-        width: 1020px;
-        max-width: 100%; /* Pour la responsivité sur petits écrans */
-        margin: 0 auto; /* Centre le conteneur */
+        max-width: var(--content-width);
+        width: 100%;
+        margin: 0 auto;
         overflow: hidden;
         border-radius: 12px;
         box-shadow: var(--box-shadow);

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -27,8 +27,8 @@ const posts = (await getCollection("blog"))
         <ClientRouter />
         <BaseHead title={t("site.title")} description={t("site.description")} />
         <style>
-            main {
-                width: 960px;
+            :root {
+                --content-width: 960px;
             }
             ul {
                 display: flex;

--- a/src/pages/[lang]/projects/index.astro
+++ b/src/pages/[lang]/projects/index.astro
@@ -27,8 +27,8 @@ const posts = (await getCollection("projects"))
         <ClientRouter />
         <BaseHead title={t("site.title")} description={t("site.description")} />
         <style>
-            main {
-                width: 1020px;
+            :root {
+                --content-width: 1020px;
             }
             ul {
                 display: flex;
@@ -51,7 +51,7 @@ const posts = (await getCollection("projects"))
                 text-align: center;
             }
             ul li:first-child img {
-                width: 1020px;
+                width: 100%;
             }
             ul li:first-child .title {
                 font-size: 2.369rem;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,6 +20,7 @@
   --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   --radius: 0.5rem;
   --box-shadow: var(--shadow);
+  --content-width: 960px;
 
   /* — Light‑theme tokens — */
   --bg-color: 248, 248, 250;
@@ -86,8 +87,8 @@ body {
 }
 main {
   flex: 1;
-  width: 720px;
-  max-width: calc(100% - 2em);
+  max-width: var(--content-width);
+  width: 100%;
   margin: auto;
   padding: 3em 1em;
   background-color: rgb(var(--bg-color));


### PR DESCRIPTION
## Summary
- add `--content-width` variable in global CSS
- base header, main, and hero image on this variable
- set page-specific width using `:root` in blog and projects pages

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6867baa0b8508323956a9e02b6994b74